### PR TITLE
Check if watched file was recreated after remove

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -133,8 +133,12 @@ fn main() -> miette::Result<()> {
                             Flow::Continue
                         }
                         EventKind::Remove(_) => {
-                            message(Red, "Error", "watched file was deleted. Exiting...");
-                            std::process::exit(1);
+                            if name.exists() {
+                                Flow::Continue
+                            } else {
+                                message(Red, "Error", "watched file was deleted. Exiting...");
+                                std::process::exit(1);
+                            }
                         }
                         _ => Flow::Continue,
                     })


### PR DESCRIPTION
Fixes #25 
When watching a file, if the file was removed, check if it still doesn't exist before exiting.