### PR TITLE
Fix memory being reclaimed too early

### DIFF
--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -33,10 +33,8 @@ impl StaticSource {
     pub fn src(&self) -> &'static str {
         unsafe { &*self.src }
     }
-}
 
-impl Drop for StaticSource {
-    fn drop(&mut self) {
+    pub fn reclaim(&mut self) {
         unsafe { drop(Box::from_raw(self.src)) }
     }
 }


### PR DESCRIPTION
Memory was being reclaimed before errors were printed.