### PR TITLE
Fix incorrect range check for PC offset values

### DIFF
--- a/src/air.rs
+++ b/src/air.rs
@@ -436,7 +436,7 @@ mod test {
         };
         assert!(asm.emit().is_err());
         let asm = AsmLine {
-            line: 256,
+            line: 257,
             stmt: AirStmt::Branch {
                 flag: Flag::Nzp,
                 dest_label: Label::Ref(1),

--- a/src/air.rs
+++ b/src/air.rs
@@ -323,7 +323,7 @@ impl AsmLine {
         let (offset, _) = label_pos.overflowing_sub(self.line);
         let offset = (offset as i16) - 1;
         // Must fit in specified offset bits
-        if offset.abs() > 2i16.pow(bits - 1) - 1 {
+        if offset.abs() > 2i16.pow(bits - 1) - if offset > 0 { 1 } else { 0 } {
             bail!(
                 severity = Severity::Error,
                 r#"Difference between label and label reference is too large: at line {}, referencing line {}


### PR DESCRIPTION
Fixes #30 
Extends the allowable PCOffset range from `-255..=255` to `-256..=255`.