### PR TITLE
Add negative hex literals

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -423,7 +423,8 @@ impl AsmParser {
     }
 }
 
-// Convenient way to pass around bit limits
+/// Convenient way to pass around bit limits
+#[derive(Debug)]
 pub enum Bits {
     Signed(u8),
     Unsigned(u8),


### PR DESCRIPTION
Allows for hex literals because that is unfortunately a legitimate usecase