### PR TITLE
Fix running and compiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+
+[[package]]
 name = "file-id"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,6 +410,7 @@ dependencies = [
  "lazy_static",
  "miette",
  "predicates",
+ "tempfile",
 ]
 
 [[package]]
@@ -564,6 +571,12 @@ checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "owo-colors"
@@ -785,6 +798,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,9 +871,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ console = "0.15.8"
 [dev-dependencies]
 assert_cmd = "2.0.14"
 predicates = "3.1.2"
+tempfile = "3.12.0"
 
 [[bin]]
 name = "lace"

--- a/src/main.rs
+++ b/src/main.rs
@@ -196,7 +196,7 @@ fn run(name: &PathBuf) -> Result<()> {
     file_message(MsgColor::Green, "Assembling", &name);
     let mut program = if let Some(ext) = name.extension() {
         match ext.to_str().unwrap() {
-            "lc3" => {
+            "lc3" | "obj" => {
                 // Read to byte buffer
                 let mut file = File::open(&name).into_diagnostic()?;
                 let f_size = file.metadata().unwrap().len();

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -13,7 +13,7 @@ const MEMORY_MAX: usize = 0x10000;
 pub struct RunState {
     /// System memory - 128KB in size.
     /// Need to figure out if this would cause problems with the stack.
-    mem: [u16; MEMORY_MAX],
+    mem: Box<[u16; MEMORY_MAX]>,
     /// Program counter
     pc: u16,
     /// 8x 16-bit registers
@@ -57,7 +57,7 @@ impl RunState {
         mem[orig..orig + raw.len()].clone_from_slice(&raw);
 
         Ok(RunState {
-            mem,
+            mem: Box::new(mem),
             pc: orig as u16,
             reg: [0; 8],
             flag: RunFlag::Uninit,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,6 +1,6 @@
-use assert_cmd::prelude::*;
+use assert_cmd::Command;
 use predicates::str::contains;
-use std::process::Command;
+use tempfile::tempdir;
 
 #[test]
 fn runs_without_arguments() {
@@ -17,4 +17,23 @@ fn runs_hello_world() {
         .success()
         .stdout(contains("Hello, world!"))
         .stdout(contains("Halted"));
+}
+
+#[test]
+fn compile_and_run() {
+    let dir = tempdir().expect("Could not make tempdir");
+
+    let outfile_path = dir.path().join("hw.lc3");
+
+    let mut cmd = Command::cargo_bin("lace").unwrap();
+    cmd.arg("compile")
+        .arg("tests/files/hw.asm")
+        .arg(&outfile_path);
+
+    cmd.assert().success().stdout(contains("Saved target"));
+
+    let mut cmd = Command::cargo_bin("lace").unwrap();
+    cmd.arg(&outfile_path);
+
+    cmd.assert().success().stdout(contains("Hello, world!"));
 }


### PR DESCRIPTION
Allow running from `.lc3` and `.obj` binaries.
Fixes #35
Fixes #27 