### PR TITLE
Add delay to automatic re-assemble

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,7 @@ fn main() -> miette::Result<()> {
                             let mut contents = StaticSource::new(
                                 fs::read_to_string(&name).into_diagnostic().unwrap(),
                             );
+                            std::thread::sleep(Duration::from_millis(100));
                             let _ = match assemble(&contents) {
                                 Ok(_) => {
                                     message(Green, "Success", "no errors found!");


### PR DESCRIPTION
When watching a file, sleep for 100ms before printing success/error message, to provide feedback to the user.