### PR TITLE
Flush stdout after `PUTS` and `OUT` traps

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,5 +1,10 @@
 use core::panic;
-use std::{cmp::Ordering, i16, io::Write, u16, u32, u8, usize};
+use std::{
+    cmp::Ordering,
+    i16,
+    io::{stdout, Write},
+    u16, u32, u8, usize,
+};
 
 use crate::Air;
 use colored::Colorize;
@@ -273,6 +278,7 @@ impl RunState {
             0x21 => {
                 let chr = (*self.reg(0) & 0xFF) as u8 as char;
                 print!("{chr}");
+                stdout().flush().unwrap();
             }
             // puts
             0x22 => {
@@ -289,6 +295,7 @@ impl RunState {
                     addr += 1;
                 }
                 print!("{string}");
+                stdout().flush().unwrap();
             }
             // in
             0x23 => {


### PR DESCRIPTION
Fixes #24
Always flush stdout after `PUTS` or `OUT` trap call.

This could *hypothetically* affect performance for programs with a large number of consecutive `OUT` operations (though I don't think this matters).
A way to solve this would be to flush stdout before `IN` trap reads stdin. Since this is the only blocking instruction, and stdout is automatically flushed when the process unwinds (triggered by `HALT` or a panic), this should work for most cases (`std::process::abort` will not cause unwinding, but if this program has to abort, it has bigger problems anyway). Regardless, with this alternative method, the problem will still occur if a large (or infinite) loop is executed before stdout can be flushed.