### PR TITLE
Support non-terminal stdin reading for `GETC` and `IN`

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,5 +1,10 @@
 use core::panic;
-use std::{cmp::Ordering, i16, io::Write, u16, u32, u8, usize};
+use std::{
+    cmp::Ordering,
+    i16,
+    io::{stdin, stdout, IsTerminal, Read, Write},
+    u16, u32, u8, usize,
+};
 
 use crate::Air;
 use colored::Colorize;
@@ -265,9 +270,15 @@ impl RunState {
         match trap_vect {
             // getc
             0x20 => {
-                let cons = Term::stdout();
-                let c = cons.read_char().unwrap();
-                *self.reg(0) = c as u16;
+                if stdin().is_terminal() {
+                    let cons = Term::stdout();
+                    let c = cons.read_char().unwrap();
+                    *self.reg(0) = c as u16;
+                } else {
+                    let mut buf = [0; 1];
+                    stdin().read_exact(&mut buf).unwrap();
+                    *self.reg(0) = buf[0] as u16;
+                }
             }
             // out
             0x21 => {
@@ -292,11 +303,19 @@ impl RunState {
             }
             // in
             0x23 => {
-                let mut cons = Term::stdout();
-                let c = cons.read_char().unwrap();
-                *self.reg(0) = c as u16;
-                write!(cons, "{c}").unwrap();
-                cons.flush().unwrap();
+                if stdin().is_terminal() {
+                    let mut cons = Term::stdout();
+                    let c = cons.read_char().unwrap();
+                    *self.reg(0) = c as u16;
+                    write!(cons, "{c}").unwrap();
+                    cons.flush().unwrap();
+                } else {
+                    let mut buf = [0; 1];
+                    stdin().read_exact(&mut buf).unwrap();
+                    *self.reg(0) = buf[0] as u16;
+                    print!("{}", buf[0] as char);
+                    stdout().flush().unwrap();
+                }
             }
             // putsp
             0x24 => {


### PR DESCRIPTION
Fixes #23
Don't use `console::Term` to read stdin, when stdin is not a terminal. Instead read to a single-character buffer using standard library functions.
Line-buffering is not a problem when stdin is not a terminal. 

Improvements that could be made:
 - Use shared `console::Term` and `std::io::Stdin` instances, instead of creating them for each `GETC`/`IN` call (`stdin()` creates a new handle the the global stdin mutex)
 - Extract the common behaviour of `GETC` and `IN` to a function