### PR TITLE
Add stack based instruction set extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ a different LC3 virtual machine to test them out until that is implemented.
 - `fmt`: **(planned)** formats your *.asm* file to fit my arbitrary style guide.
 - `clean`: **(planned)** used to clean debug artifacts that will be implemented in the future.
 
+## Instruction set extension
+LC3 is unfortunately limited in terms of functionality, with the absence of a stack being the most painful missing feature.
+Luckily, LC3 also comes with a spare opcode (0b1101/0xD), which I have used to implement stack-based instructions on top 
+of the existing set. The new instructions are:
+- `call` - call a subroutine using a label with 10 bits of precision, and push program counter to stack (usage: `call label`)
+- `rets` - pop address off the stack and set program counter to its value (usage: `rets` after calling subroutine)
+- `push` - push the contents of a register onto the stack (usage: `push r0`)
+- `pop` - pop the top value of the stack off into a register (usage: `pop r0` after pushing)
+
+Please note that these instructions will only function when using the `lace` virtual machine and `run` command.
+
 ## Traps
 There are a few extra traps that should make debugging a lot nicer! Please note that they will not perform as expected when you run
 your binaries with other virtual machines.
@@ -29,7 +40,6 @@ your binaries with other virtual machines.
 
 ## Work in progress
 There are several features and fixes under development:
-- Putsp trap
 - Showing multiple errors per compilation
 - Different number formats for console output
 - File formatting
@@ -50,6 +60,18 @@ cd lace
 cargo install --path .
 ```
 You should, as a result, have the `lace` binary available in your PATH.
+
+## Examples
+Some examples are available under the *tests/files* directory for testing purposes. You can run them with LC3, e.g.
+`lace run tests/files/hw.asm`.
+
+## Contributors
+A huge thank you to [@dxrcy](https://github.com/dxrcy) for various additions and bugfixes, including continued work
+on the debugger implementation!
+
+<a href="https://github.com/rozukke/lace/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=rozukke/lace" />
+</a>
 
 ## License
 Copyright (c) 2024 Artemis Rosman

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -338,6 +338,10 @@ impl Cursor<'_> {
             "st" => Instr(St),
             "sti" => Instr(Sti),
             "str" => Instr(Str),
+            "pop" => Instr(Pop),
+            "push" => Instr(Push),
+            "call" => Instr(Call),
+            "rets" => Instr(Rets),
             _ => TokenKind::Label,
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -199,6 +199,20 @@ impl AsmParser {
     fn parse_instr(&mut self, kind: InstrKind) -> Result<AirStmt> {
         use crate::symbol::InstrKind;
         match kind {
+            InstrKind::Push => {
+                let src_reg = self.expect_reg()?;
+                Ok(AirStmt::Push { src_reg })
+            }
+            InstrKind::Pop => {
+                let dest_reg = self.expect_reg()?;
+                Ok(AirStmt::Pop { dest_reg })
+            }
+            InstrKind::Call => {
+                let label_tok = self.expect(TokenKind::Label)?;
+                let dest_label = Label::try_fill(self.get_span(label_tok.span));
+                Ok(AirStmt::Call { dest_label })
+            }
+            InstrKind::Rets => Ok(AirStmt::Rets),
             InstrKind::Add => {
                 let dest = self.expect_reg()?;
                 let src_reg = self.expect_reg()?;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -64,29 +64,29 @@ impl RunState {
         Ok(RunState {
             mem: Box::new(mem),
             pc: orig as u16,
-            reg: [0; 8],
+            reg: [0, 0, 0, 0, 0, 0, 0, 0xFDFF],
             flag: RunFlag::Uninit,
             _psr: 0,
         })
     }
 
     const OP_TABLE: [fn(&mut RunState, u16); 16] = [
-        Self::br,   // 0x0
-        Self::add,  // 0x1
-        Self::ld,   // 0x2
-        Self::st,   // 0x3
-        Self::jsr,  // 0x4
-        Self::and,  // 0x5
-        Self::ldr,  // 0x6
-        Self::str,  // 0x7
-        Self::rti,  // 0x8
-        Self::not,  // 0x9
-        Self::ldi,  // 0xA
-        Self::sti,  // 0xB
-        Self::jmp,  // 0xC
-        Self::nul,  // 0xD
-        Self::lea,  // 0xE
-        Self::trap, // 0xF
+        Self::br,    // 0x0
+        Self::add,   // 0x1
+        Self::ld,    // 0x2
+        Self::st,    // 0x3
+        Self::jsr,   // 0x4
+        Self::and,   // 0x5
+        Self::ldr,   // 0x6
+        Self::str,   // 0x7
+        Self::rti,   // 0x8
+        Self::not,   // 0x9
+        Self::ldi,   // 0xA
+        Self::sti,   // 0xB
+        Self::jmp,   // 0xC
+        Self::stack, // 0xD
+        Self::lea,   // 0xE
+        Self::trap,  // 0xF
     ];
 
     /// Run with preset memory
@@ -137,8 +137,46 @@ impl RunState {
         }
     }
 
-    fn nul(&mut self, _instr: u16) {
-        panic!("You called a reserved instruction. Halting...")
+    fn stack(&mut self, instr: u16) {
+        // Bit to determine call/ret or push/pop
+        if instr & 0x0800 != 0 {
+            // Call
+            if instr & 0x0400 != 0 {
+                self.push_val(self.pc);
+                self.pc = self.pc.wrapping_add(Self::s_ext(instr, 10));
+            }
+            // Ret
+            else {
+                self.pc = self.pop_val();
+            }
+        } else {
+            let reg = (instr >> 6) & 0b111;
+            // Push
+            if instr & 0x0400 != 0 {
+                let val = *self.reg(reg);
+                self.push_val(val);
+            }
+            // Pop
+            else {
+                let val = self.pop_val();
+                *self.reg(reg) = val;
+            }
+        }
+    }
+
+    fn push_val(&mut self, val: u16) {
+        // Decrement stack
+        *self.reg(7) -= 1;
+        let sp = *self.reg(7);
+        // Save onto stack
+        *self.mem(sp) = val;
+    }
+
+    fn pop_val(&mut self) -> u16 {
+        let sp = *self.reg(7);
+        let val = *self.mem(sp);
+        *self.reg(7) += 1;
+        val
     }
 
     fn add(&mut self, instr: u16) {

--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -248,6 +248,10 @@ pub enum InstrKind {
     St,
     Sti,
     Str,
+    Pop,
+    Push,
+    Call,
+    Rets,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]

--- a/tests/files/fibonacci.asm
+++ b/tests/files/fibonacci.asm
@@ -1,0 +1,47 @@
+main:
+        ld r0 n
+        call fib
+        reg
+        halt
+
+; variables
+n:      .fill #23
+
+; n in r0, result in r1
+fib:
+        push r2
+        ; accumulator
+        and r1 r1 #0
+        ; workspace
+        and r2 r2 #0
+
+        push r0
+        call fib_inner
+        pop r0
+
+        pop r2
+        rets
+
+fib_inner:
+        ; access stack variable
+        ldr r0 r7 #1
+        and r2 r2 #0
+        add r2 r0 #-1
+        brnz fib_post
+
+        add r0 r0 #-1
+        push r0
+        call fib_inner
+        pop r0
+
+        add r0 r0 #-1
+        push r0
+        call fib_inner
+        pop r0
+
+        rets
+
+; bottom of recursive call
+fib_post:
+        add r1 r1 r0
+        rets

--- a/tests/files/stack.asm
+++ b/tests/files/stack.asm
@@ -1,0 +1,28 @@
+main
+    ; do subroutine with stack
+    call hw_sub
+    ; print return from call
+    lea r0 sr
+    puts
+    ; test stack
+    add r1 r1 #5
+    push r1
+    pop r2
+    ; ascii offset
+    ld r3 offs
+    add r2 r2 r3
+    ; change res string
+    lea r0 res
+    str r2 r0 #16
+    puts
+    halt
+
+hw_sub
+    lea r0 hw
+    puts
+    rets
+
+hw .stringz "Hello from the stack\n"
+sr .stringz "Returned from call\n"
+res .stringz "R2 contents are _\n"
+offs .fill 0x30

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -20,6 +20,29 @@ fn runs_hello_world() {
 }
 
 #[test]
+fn runs_stack_example() {
+    let mut cmd = Command::cargo_bin("lace").unwrap();
+    cmd.arg("run").arg("tests/files/stack.asm");
+
+    cmd.assert()
+        .success()
+        .stdout(contains("Hello from the stack"))
+        .stdout(contains("Returned from call"))
+        .stdout(contains("R2 contents are 5"));
+}
+
+#[test]
+fn runs_recursive_fibonacci_example() {
+    let mut cmd = Command::cargo_bin("lace").unwrap();
+    cmd.arg("run").arg("tests/files/fibonacci.asm");
+
+    // Hardcoded 23rd fibonacci number
+    cmd.assert()
+        .success()
+        .stdout(contains("28657"));
+}
+
+#[test]
 fn compile_and_run() {
     let dir = tempdir().expect("Could not make tempdir");
 


### PR DESCRIPTION
Add instructions:
- `call` to jump into subroutine with stack
- `rets` to return from subroutine with stack
- `push` to push onto stack
- `pop` to pop from stack

Also adds tests for new instructions