### PR TITLE
Separate runtime register/memory methods into mutable and immutable versions

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -106,8 +106,14 @@ impl RunState {
 
     #[inline]
     fn reg(&mut self, reg: u16) -> &mut u16 {
+        let value = self.reg.get_mut(reg as usize);
+        debug_assert!(
+            value.is_some(),
+            "tried to access invalid register 'r{}'",
+            reg
+        );
         // SAFETY: Should only be indexed with values that are & 0b111
-        unsafe { self.reg.get_unchecked_mut(reg as usize) }
+        unsafe { value.unwrap_unchecked() }
     }
 
     #[inline]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -106,25 +106,15 @@ impl RunState {
 
     #[inline]
     fn reg(&self, reg: u16) -> u16 {
-        let value = self.reg.get(reg as usize);
-        debug_assert!(
-            value.is_some(),
-            "tried to access invalid register 'r{}'",
-            reg
-        );
+        debug_assert!(reg < 8, "tried to access invalid register 'r{}'", reg);
         // SAFETY: Should only be indexed with values that are & 0b111
-        unsafe { *value.unwrap_unchecked() }
+        unsafe { *self.reg.get_unchecked(reg as usize) }
     }
     #[inline]
     fn reg_mut(&mut self, reg: u16) -> &mut u16 {
-        let value = self.reg.get_mut(reg as usize);
-        debug_assert!(
-            value.is_some(),
-            "tried to access invalid register 'r{}'",
-            reg
-        );
+        debug_assert!(reg < 8, "tried to access invalid register 'r{}'", reg);
         // SAFETY: Should only be indexed with values that are & 0b111
-        unsafe { value.unwrap_unchecked() }
+        unsafe { self.reg.get_unchecked_mut(reg as usize) }
     }
 
     #[inline]


### PR DESCRIPTION
Intended to make runtime API safer and more usable, for future trap extension functionality.

Change `RunState` methods:
 - Rename `reg` and `mem` to `reg_mut` and `mem_mut` respectively.
 - Add new *immutable* `reg` and `mem` methods, which return a copy of the word value.
 - Add `debug_assert` checks to register methods (memory methods should always be safe).

Update calls to `reg` and `mem` methods from within `RunState`.

Possible improvements:
- Register and memory methods could safely `expect` instead of `unwrap_unchecked` (negligible performance cost).
- `crate::symbol::Register` could instead be used within the runtime, and be exposed publicly.
