### PR TITLE
Fix 2 typos

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,7 @@ fn main() -> miette::Result<()> {
                 Ok(())
             }
             Command::Compile { name, dest } => {
-                file_message(Green, "Assembing", &name);
+                file_message(Green, "Assembling", &name);
                 let contents = StaticSource::new(fs::read_to_string(&name).into_diagnostic()?);
                 let air = assemble(&contents)?;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -156,7 +156,7 @@ impl AsmParser {
                     TokenKind::Label | TokenKind::Lit(_) | TokenKind::Reg(_) => {
                         return Err(error::parse_generic_unexpected(
                             self.src,
-                            "directive/instrucion/trap",
+                            "directive/instruction/trap",
                             tok,
                         ))
                     }


### PR DESCRIPTION
Codebase was scanned using an NN model (nonartificial nonintelligence) for spelling errors and two were found.

Needless to say this is a very severe issue.