### PR TITLE
Show descriptive messages on fail to read stdin

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,7 +1,7 @@
 use std::{
     cmp::Ordering,
     i16,
-    io::{stdin, stdout, IsTerminal, Read, Write},
+    io::{self, stdin, stdout, IsTerminal, Read, Write},
     u16, u32, u8, usize,
 };
 
@@ -432,11 +432,21 @@ impl RunState {
 fn read_input() -> u8 {
     if stdin().is_terminal() {
         let cons = Term::stdout();
-        let ch = cons.read_char().unwrap();
+        let ch = cons
+            .read_char()
+            .expect("read from interactive terminal should not fail");
         ch as u8
     } else {
         let mut buf = [0; 1];
-        stdin().read_exact(&mut buf).unwrap();
+        if let Err(err) = stdin().read_exact(&mut buf) {
+            match err.kind() {
+                io::ErrorKind::UnexpectedEof => {
+                    eprintln!("unexpected end of input file stream.");
+                    std::process::exit(1);
+                }
+                _ => panic!("failed to read character from stdin: {:?}", err),
+            }
+        }
         buf[0]
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -439,12 +439,11 @@ fn read_input() -> u8 {
     } else {
         let mut buf = [0; 1];
         if let Err(err) = stdin().read_exact(&mut buf) {
-            match err.kind() {
-                io::ErrorKind::UnexpectedEof => {
-                    eprintln!("unexpected end of input file stream.");
-                    std::process::exit(1);
-                }
-                _ => panic!("failed to read character from stdin: {:?}", err),
+            if let io::ErrorKind::UnexpectedEof = err.kind() {
+                eprintln!("unexpected end of input file stream.");
+                std::process::exit(1);
+            } else {
+                panic!("failed to read character from stdin: {:?}", err)
             }
         }
         buf[0]


### PR DESCRIPTION
When `read_input` fails, the panic message is now more descriptive than an anonymous `unwrap`.
Especially helpful for when non-terminal stdin reaches EOF.

Fixes #57.