### PR TITLE
ci: publish releases on push with semver tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Publish release
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact_name: ${{ github.event.repository.name }}
+            asset_name: ${{ github.event.repository.name }}-linux-amd64
+          - os: windows-latest
+            artifact_name: ${{ github.event.repository.name }}.exe
+            asset_name: ${{ github.event.repository.name }}-windows-amd64.exe
+          - os: macos-latest
+            artifact_name: ${{ github.event.repository.name }}
+            asset_name: ${{ github.event.repository.name }}-macos-amd64
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build
+      run: cargo build --release --locked --verbose
+
+    - name: Upload binaries to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: target/release/${{ matrix.artifact_name }}
+        asset_name: ${{ matrix.asset_name }}
+        tag: ${{ github.ref }}
+        make_latest: true
+


### PR DESCRIPTION
After committing/pushing as normal, create a new tag and push it. Tag must be in semver `vM.m.p` format (no trailing characters like `-alpha`) for workflow to run.

```sh
# git commit ...
# git push ...
git tag v1.0.15
git push origin v1.0.15
```

New release will created with corresponding tag and builds for 3 platforms. Release is automatically published, **NOT** drafted (due to a bug/limitation with `svenstaro/upload-release-action`).
![image](https://github.com/user-attachments/assets/ca583161-52e7-4997-a842-e769635ea612)

Note that the binary builds created by `rust.yml` cannot be used as they are not built for release.

Attributes which may be changed before merging:
- Release name (currently tag name)
- Release body/description (currently empty)
- Asset names