### PR TITLE
Fix incorrect parsing of ';' with literals

### DIFF
--- a/src/debugger/command/parse/mod.rs
+++ b/src/debugger/command/parse/mod.rs
@@ -21,7 +21,7 @@ pub struct Arguments<'a> {
 
     /// Amount of arguments requested (successfully or not).
     ///
-    /// Must only be incremented by [`Self::next_str`].
+    /// Must only be incremented by [`Self::next_argument_str`].
     arg_count: u8,
 }
 

--- a/src/debugger/command/reader/terminal.rs
+++ b/src/debugger/command/reader/terminal.rs
@@ -424,7 +424,7 @@ fn find_word_next(string: &str, cursor: usize, full_word: bool) -> usize {
 
 /// Return character index of end of the word to the right of cursor. Uses Vim rules.
 ///
-/// See [`find_word_start`]
+/// See [`find_word_next`]
 // TODO(refactor/opt): Rewrite to be more idiomaticly Rust
 fn find_word_back(string: &str, mut cursor: usize, full_word: bool) -> usize {
     // At start of line

--- a/src/lexer/cursor.rs
+++ b/src/lexer/cursor.rs
@@ -1,5 +1,5 @@
 //! Heavily inspired and referenced from `rustc_lexer` and adapted to suit the project.
-//! See https://doc.rust-lang.org/beta/nightly-rustc/src/rustc_lexer/cursor.rs.html
+//! See <https://doc.rust-lang.org/beta/nightly-rustc/src/rustc_lexer/cursor.rs.html>
 
 use std::{ops::Range, str::Chars};
 

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -479,13 +479,13 @@ mod test {
 
     #[test]
     fn str_escaped() {
-        let mut lex = Cursor::new(r#"there is an escaped \" in this str\n"#);
+        let mut lex = Cursor::new(r#""there is an escaped \" in this str\n""#);
         assert!(lex.advance_token().is_ok())
     }
 
     #[test]
     fn str_comment() {
-        let mut lex = Cursor::new(r#"there is an escaped \" in this str\n;"#);
+        let mut lex = Cursor::new(r#""there is an escaped \" in this str\n;""#);
         assert!(lex.advance_token().is_ok())
     }
 
@@ -521,9 +521,9 @@ mod test {
 
     #[test]
     fn register_comment() {
-        let mut lex = Cursor::new("R0");
+        let mut lex = Cursor::new("R0;");
         assert_eq!(
-            lex.advance_real().unwrap().kind,
+            lex.advance_token().unwrap().kind,
             TokenKind::Reg(Register::R0)
         );
     }

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -91,7 +91,8 @@ impl Display for TokenKind {
     }
 }
 
-/// Test if a character is considered to be whitespace, including commas.
+/// Test if a character is considered to be whitespace, including commas
+/// or colons but not semicolons
 pub(crate) fn is_whitespace(c: char) -> bool {
     char::is_ascii_whitespace(&c) || matches!(c, ',' | ':')
 }

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -421,6 +421,13 @@ mod test {
         assert_eq!(res.kind, TokenKind::Label)
     }
 
+    #[test]
+    fn hex_comment() {
+        let mut lex = Cursor::new("0xa;");
+        let res = lex.advance_token().unwrap();
+        assert_eq!(res.kind, TokenKind::Lit(LiteralKind::Hex(0xa)))
+    }
+
     // DEC LIT TESTS
 
     #[test]
@@ -455,6 +462,13 @@ mod test {
         assert!(lex.advance_real().is_err());
     }
 
+    #[test]
+    fn dec_comment() {
+        let mut lex = Cursor::new("#-300;");
+        let res = lex.advance_token().unwrap();
+        assert!(res.kind == TokenKind::Lit(LiteralKind::Dec(-300)))
+    }
+
     // STR LIT TESTS
 
     #[test]
@@ -466,6 +480,12 @@ mod test {
     #[test]
     fn str_escaped() {
         let mut lex = Cursor::new(r#"there is an escaped \" in this str\n"#);
+        assert!(lex.advance_token().is_ok())
+    }
+
+    #[test]
+    fn str_comment() {
+        let mut lex = Cursor::new(r#"there is an escaped \" in this str\n;"#);
         assert!(lex.advance_token().is_ok())
     }
 
@@ -496,6 +516,15 @@ mod test {
         assert_eq!(
             lex.advance_real().unwrap().kind,
             TokenKind::Reg(Register::R7)
+        );
+    }
+
+    #[test]
+    fn register_comment() {
+        let mut lex = Cursor::new("R0");
+        assert_eq!(
+            lex.advance_real().unwrap().kind,
+            TokenKind::Reg(Register::R0)
         );
     }
 

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -191,9 +191,7 @@ impl Cursor<'_> {
     fn hex(&mut self) -> Result<TokenKind> {
         let start = self.abs_pos();
         let prefix = self.pos_in_token();
-        self.take_while(|c| {
-            c.is_numeric() || matches!(c.to_ascii_lowercase(), 'x' | '-' | 'a'..='f')
-        });
+        self.take_while(|c| !is_whitespace(c) && c != ';');
         let str_val = self.get_range(start..self.abs_pos());
         let value = match i16::from_str_radix(str_val, 16) {
             Ok(value) => value as u16,
@@ -218,7 +216,7 @@ impl Cursor<'_> {
     fn dec(&mut self) -> Result<TokenKind> {
         let start = self.abs_pos();
         let prefix = self.pos_in_token();
-        self.take_while(|c| c.is_numeric() || matches!(c, '#' | '-'));
+        self.take_while(|c| !is_whitespace(c) && c != ';');
         let str_val = self.get_range(start..self.abs_pos());
 
         // i16 to handle negative values

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -191,7 +191,9 @@ impl Cursor<'_> {
     fn hex(&mut self) -> Result<TokenKind> {
         let start = self.abs_pos();
         let prefix = self.pos_in_token();
-        self.take_while(|c| c.is_numeric() || matches!(c.to_ascii_lowercase(), 'x' | '-' | 'a'..='f' ));
+        self.take_while(|c| {
+            c.is_numeric() || matches!(c.to_ascii_lowercase(), 'x' | '-' | 'a'..='f')
+        });
         let str_val = self.get_range(start..self.abs_pos());
         let value = match i16::from_str_radix(str_val, 16) {
             Ok(value) => value as u16,

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -149,7 +149,7 @@ impl Cursor<'_> {
                     self.take_while(is_reg_num);
                     if self.pos_in_token() == 2
                         && match self.first() {
-                            c if is_whitespace(c) => true,
+                            c if is_whitespace(c) || c == ';' => true,
                             '\0' => true,
                             _ => false,
                         }
@@ -191,7 +191,7 @@ impl Cursor<'_> {
     fn hex(&mut self) -> Result<TokenKind> {
         let start = self.abs_pos();
         let prefix = self.pos_in_token();
-        self.take_while(|c| !is_whitespace(c));
+        self.take_while(|c| c.is_numeric() || matches!(c.to_ascii_lowercase(), 'x' | '-' | 'a'..='f' ));
         let str_val = self.get_range(start..self.abs_pos());
         let value = match i16::from_str_radix(str_val, 16) {
             Ok(value) => value as u16,
@@ -216,7 +216,7 @@ impl Cursor<'_> {
     fn dec(&mut self) -> Result<TokenKind> {
         let start = self.abs_pos();
         let prefix = self.pos_in_token();
-        self.take_while(|c| !is_whitespace(c));
+        self.take_while(|c| c.is_numeric() || matches!(c, '#' | '-'));
         let str_val = self.get_range(start..self.abs_pos());
 
         // i16 to handle negative values

--- a/src/term.rs
+++ b/src/term.rs
@@ -5,7 +5,7 @@ use crossterm::{
     terminal,
 };
 
-/// Similar to [`crossterm::Event::KeyCode`] but only contains relevant information.
+/// Similar to [`crossterm::event::KeyCode`] but only contains relevant information.
 #[derive(Debug)]
 pub enum Key {
     Enter,


### PR DESCRIPTION
Fixes statements such as "#03;" and "0x3;"